### PR TITLE
URL Cleanup

### DIFF
--- a/impl/src/test/java/com/example/legacyapp/services/OnlineModeTests.java
+++ b/impl/src/test/java/com/example/legacyapp/services/OnlineModeTests.java
@@ -24,7 +24,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 		webEnvironment = NONE)
 @AutoConfigureStubRunner(
 		ids = "com.example.github:github-webhook:+:stubs:7654",
-		repositoryRoot = "http://repo.spring.io/libs-milestone-local"
+		repositoryRoot = "https://repo.spring.io/libs-milestone-local"
 )
 public class OnlineModeTests {
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://repo.spring.io/libs-milestone-local with 1 occurrences migrated to:  
  https://repo.spring.io/libs-milestone-local ([https](https://repo.spring.io/libs-milestone-local) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost:7654/ with 1 occurrences