### PR TITLE
URL Cleanup

### DIFF
--- a/impl/src/test/java/com/example/legacyapp/services/OnlineModeTests.java
+++ b/impl/src/test/java/com/example/legacyapp/services/OnlineModeTests.java
@@ -24,7 +24,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 		webEnvironment = NONE)
 @AutoConfigureStubRunner(
 		ids = "com.example.github:github-webhook:+:stubs:7654",
-		repositoryRoot = "http://repo.spring.io/libs-milestone-local"
+		repositoryRoot = "https://repo.spring.io/libs-milestone-local"
 )
 public class OnlineModeTests {
 

--- a/stubs_with_proxy/src/test/java/com/example/proxy/AbstractStubsFromProxy.java
+++ b/stubs_with_proxy/src/test/java/com/example/proxy/AbstractStubsFromProxy.java
@@ -55,7 +55,7 @@ public abstract class AbstractStubsFromProxy {
 	 * <pre>
 	 *     WireMock.startRecording(
 	 *     WireMock.recordSpec()
-	 *     .forTarget("http://example.mocklab.io")
+	 *     .forTarget("https://example.mocklab.io")
 	 *     .onlyRequestsMatching(getRequestedFor(urlPathMatching("/api/.*")))
 	 *     .captureHeader("Accept")
 	 *     .captureHeader("Content-Type", true)


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://example.mocklab.io (404) with 1 occurrences migrated to:  
  https://example.mocklab.io ([https](https://example.mocklab.io) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://repo.spring.io/libs-milestone-local with 1 occurrences migrated to:  
  https://repo.spring.io/libs-milestone-local ([https](https://repo.spring.io/libs-milestone-local) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 1 occurrences
* http://localhost:6765 with 1 occurrences
* http://localhost:7654/ with 1 occurrences